### PR TITLE
Fix typo in README of gtag-react package

### DIFF
--- a/packages/gtag-react/README.md
+++ b/packages/gtag-react/README.md
@@ -1,4 +1,4 @@
-# @deptno/gtag-teact
+# @deptno/gtag-react
 [![npm](https://img.shields.io/npm/dt/@deptno/gtag-react.svg?style=for-the-badge)](https://www.npmjs.com/package/@deptno/gtag-react)
 
 > @WIP


### PR DESCRIPTION
Fix typo in README of `gtag-react` package.